### PR TITLE
[#issue19] 로그 테이블 페이지 구현 

### DIFF
--- a/app/ClientProviders.tsx
+++ b/app/ClientProviders.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { ReactNode } from 'react'
+
+import { ChakraProvider } from '@chakra-ui/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+
+const queryClient = new QueryClient()
+
+export default function ClientProviders({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ChakraProvider>
+        {children}
+        <ReactQueryDevtools initialIsOpen={false} />
+      </ChakraProvider>
+    </QueryClientProvider>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import TabBar from '@/components/TabBar'
 
-import ChakraWrapper from './chakra-provider'
+import ClientProviders from './ClientProviders'
 
 export const metadata = {
   title: 'capstone_design_fe',
@@ -15,7 +15,7 @@ export default function RootLayout({
   return (
     <html lang="kr" style={{ overflow: 'hidden' }}>
       <body style={{ margin: 0, height: '100%', overflow: 'hidden' }}>
-        <ChakraWrapper>
+        <ClientProviders>
           <div
             style={{
               display: 'flex',
@@ -40,14 +40,15 @@ export default function RootLayout({
                 flex: 1,
                 display: 'flex',
                 justifyContent: 'center',
-                alignItems: 'center',
+                alignItems: 'flex-start',
+                padding: '0',
                 overflow: 'hidden',
               }}
             >
               {children}
             </div>
           </div>
-        </ChakraWrapper>
+        </ClientProviders>
       </body>
     </html>
   )

--- a/app/record/page.tsx
+++ b/app/record/page.tsx
@@ -1,37 +1,20 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-
-import { LogEntry, fetchLogs } from '@/hooks/useLog'
+import { useLogQuery } from '@/hooks/useLog'
 
 export default function RecordPage() {
-  const [logs, setLogs] = useState<LogEntry[]>([])
-
-  useEffect(() => {
-    const loadLogs = async () => {
-      try {
-        const data = await fetchLogs(0, 10)
-        setLogs(data.logs)
-      } catch (error) {
-        console.error('로그 불러오기 실패:', error)
-      }
-    }
-
-    loadLogs()
-  }, [])
+  const { data } = useLogQuery(0, 10)
 
   return (
-    <main>
-      <h1>Record Page</h1>
-      <p>이곳은 딜레이 확인 페이지입니다.</p>
-
+    <div>
+      <h2>로그 목록</h2>
       <ul>
-        {logs.map((log) => (
+        {data?.logs.map((log) => (
           <li key={log.id}>
-            [{log.direction}], {log.createdAt}, {log.classes.join(', ')}
+            [{log.direction}], {log.createdAt}, {log.classes.join(', ')}, ({log.confidence})
           </li>
         ))}
       </ul>
-    </main>
+    </div>
   )
 }

--- a/app/record/page.tsx
+++ b/app/record/page.tsx
@@ -11,6 +11,11 @@ export default function RecordPage() {
 
   const { data, isLoading } = useLogQuery(currentPage - 1, pageSize)
 
+  const handlePageChange = (page: number, size: number) => {
+    setCurrentPage(page)
+    setPageSize(size)
+  }
+
   return (
     <div style={{ width: '95%', maxWidth: '1440px', padding: '0 4px' }}>
       {!isLoading && data && (
@@ -19,7 +24,7 @@ export default function RecordPage() {
           total={data.totalPage * pageSize}
           pageSize={pageSize}
           current={currentPage}
-          onPageChange={() => {}}
+          onPageChange={handlePageChange}
         />
       )}
     </div>

--- a/app/record/page.tsx
+++ b/app/record/page.tsx
@@ -1,20 +1,27 @@
 'use client'
 
+import { useState } from 'react'
+
+import RecordTable from '@/components/RecordTable'
 import { useLogQuery } from '@/hooks/useLog'
 
 export default function RecordPage() {
-  const { data } = useLogQuery(0, 10)
+  const [currentPage, setCurrentPage] = useState(1)
+  const [pageSize, setPageSize] = useState(10)
+
+  const { data, isLoading } = useLogQuery(currentPage - 1, pageSize)
 
   return (
-    <div>
-      <h2>로그 목록</h2>
-      <ul>
-        {data?.logs.map((log) => (
-          <li key={log.id}>
-            [{log.direction}], {log.createdAt}, {log.classes.join(', ')}, ({log.confidence})
-          </li>
-        ))}
-      </ul>
+    <div style={{ width: '95%', maxWidth: '1440px', padding: '0 4px' }}>
+      {!isLoading && data && (
+        <RecordTable
+          logs={data.logs}
+          total={data.totalPage * pageSize}
+          pageSize={pageSize}
+          current={currentPage}
+          onPageChange={() => {}}
+        />
+      )}
     </div>
   )
 }

--- a/app/record/page.tsx
+++ b/app/record/page.tsx
@@ -1,8 +1,37 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { LogEntry, fetchLogs } from '@/hooks/useLog'
+
 export default function RecordPage() {
+  const [logs, setLogs] = useState<LogEntry[]>([])
+
+  useEffect(() => {
+    const loadLogs = async () => {
+      try {
+        const data = await fetchLogs(0, 10)
+        setLogs(data.logs)
+      } catch (error) {
+        console.error('로그 불러오기 실패:', error)
+      }
+    }
+
+    loadLogs()
+  }, [])
+
   return (
     <main>
       <h1>Record Page</h1>
       <p>이곳은 딜레이 확인 페이지입니다.</p>
+
+      <ul>
+        {logs.map((log) => (
+          <li key={log.id}>
+            [{log.direction}], {log.createdAt}, {log.classes.join(', ')}
+          </li>
+        ))}
+      </ul>
     </main>
   )
 }

--- a/src/components/RecordTable.tsx
+++ b/src/components/RecordTable.tsx
@@ -41,11 +41,26 @@ const RecordTable = ({
       key: 'label',
       width: 640,
       render: (classes: string[]) => (
-        <div>
-          {classes.map((cls, index) => {
-            const label = cls.toLowerCase().replace(/_/g, ' ')
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '4px',
+            maxWidth: '100%',
+          }}
+        >
+          {classes.map((cls) => {
+            const lower = cls.toLowerCase()
+            const label = lower.replace(/_/g, ' ')
             return (
-              <span key={index} style={{ marginRight: 8, fontSize: '12px' }}>
+              <span
+                key={cls}
+                style={{
+                  borderRadius: '17px',
+                  fontSize: '11px',
+                  padding: '0 6px',
+                }}
+              >
                 {label}
               </span>
             )
@@ -89,7 +104,14 @@ const RecordTable = ({
           columns={columns}
           dataSource={logs}
           size="small"
-          pagination={false}
+          pagination={{
+            pageSize,
+            total,
+            current,
+            onChange: onPageChange,
+            showSizeChanger: false,
+            position: ['bottomCenter'],
+          }}
         />
       </div>
     </div>

--- a/src/components/RecordTable.tsx
+++ b/src/components/RecordTable.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { Table } from 'antd'
+import type { ColumnsType } from 'antd/es/table'
+
+import { LogEntry } from '@/hooks/useLog'
+
+interface Props {
+  logs: LogEntry[]
+  total: number
+  pageSize: number
+  current: number
+  onPageChange: (page: number, pageSize: number) => void
+}
+
+const RecordTable = ({
+  logs,
+  pageSize,
+  current,
+  total,
+  onPageChange,
+}: Props) => {
+  const columns: ColumnsType<LogEntry> = [
+    {
+      title: 'Image',
+      dataIndex: 'imageUrl',
+      key: 'image',
+      width: 85,
+      render: (url: string) => <img src={url} alt="캡쳐 이미지" />,
+    },
+    {
+      title: 'Direction',
+      dataIndex: 'direction',
+      key: 'direction',
+      width: 100,
+      render: (text) => <span>{text.toLowerCase()}</span>,
+    },
+    {
+      title: 'Label',
+      dataIndex: 'classes',
+      key: 'label',
+      width: 640,
+      render: (classes: string[]) => (
+        <div>
+          {classes.map((cls, index) => {
+            const label = cls.toLowerCase().replace(/_/g, ' ')
+            return (
+              <span key={index} style={{ marginRight: 8, fontSize: '12px' }}>
+                {label}
+              </span>
+            )
+          })}
+        </div>
+      ),
+    },
+    {
+      title: 'Date',
+      dataIndex: 'createdAt',
+      key: 'createdAt',
+      render: (value: string) => value.slice(0, 10),
+    },
+    {
+      title: 'Time',
+      dataIndex: 'createdAt',
+      key: 'time',
+      render: (value: string) => value.slice(11, 19),
+    },
+    {
+      title: 'Confidence',
+      dataIndex: 'confidence',
+      key: 'confidence',
+      width: 80,
+      render: (value: number) => value.toFixed(2),
+    },
+  ]
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        width: '100%',
+        padding: 0,
+      }}
+    >
+      <div style={{ width: '100%', maxWidth: '1200px' }}>
+        <Table
+          rowKey="id"
+          columns={columns}
+          dataSource={logs}
+          size="small"
+          pagination={false}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default RecordTable

--- a/src/components/RecordTable.tsx
+++ b/src/components/RecordTable.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Table } from 'antd'
+import { Table, Tag } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 
 import { LogEntry } from '@/hooks/useLog'
@@ -11,6 +11,16 @@ interface Props {
   pageSize: number
   current: number
   onPageChange: (page: number, pageSize: number) => void
+}
+
+const classColorMap: Record<string, string> = {
+  tree: 'green',
+  paper_box: 'blue',
+  traffic_sign: 'volcano',
+  container: 'purple',
+  plastic: 'cyan',
+  disposable_cup: 'geekblue',
+  wooden_building: 'gold',
 }
 
 const RecordTable = ({
@@ -33,7 +43,7 @@ const RecordTable = ({
       dataIndex: 'direction',
       key: 'direction',
       width: 100,
-      render: (text) => <span>{text.toLowerCase()}</span>,
+      render: (text) => <Tag>{text.toLowerCase()}</Tag>,
     },
     {
       title: 'Label',
@@ -52,17 +62,23 @@ const RecordTable = ({
           {classes.map((cls) => {
             const lower = cls.toLowerCase()
             const label = lower.replace(/_/g, ' ')
+            const color = classColorMap[lower] || 'default'
+
             return (
-              <span
+              <Tag
                 key={cls}
+                color={color}
                 style={{
-                  borderRadius: '17px',
+                  marginBottom: 4,
+                  borderRadius: '16px',
                   fontSize: '11px',
                   padding: '0 6px',
+                  lineHeight: '18px',
+                  whiteSpace: 'normal',
                 }}
               >
                 {label}
-              </span>
+              </Tag>
             )
           })}
         </div>

--- a/src/hooks/useLog.ts
+++ b/src/hooks/useLog.ts
@@ -1,3 +1,4 @@
+import { useQuery } from '@tanstack/react-query'
 import axios from 'axios'
 
 export type LogEntry = {
@@ -14,22 +15,28 @@ export type GetLogsResponse = {
   logs: LogEntry[]
 }
 
-export async function fetchLogs(
+export const useLogQuery = (
   page: number,
   size: number,
   classType?: string,
   directionType?: string
-): Promise<GetLogsResponse> {
-  const response = await axios.get<GetLogsResponse>(
-    'http://15.164.163.252:8080/api/logs',
-    {
-      params: {
-        page,
-        size,
-        classType,
-        directionType,
-      },
-    }
-  )
-  return response.data
+) => {
+  return useQuery({
+    queryKey: ['logs', page, size, classType, directionType],
+    queryFn: async () => {
+      const response = await axios.get<GetLogsResponse>(
+        'http://15.164.163.252:8080/api/logs',
+        {
+          params: {
+            page,
+            size,
+            classType,
+            directionType,
+          },
+        }
+      )
+      return response.data
+    },
+    staleTime: 5000,
+  })
 }

--- a/src/hooks/useLog.ts
+++ b/src/hooks/useLog.ts
@@ -1,0 +1,35 @@
+import axios from 'axios'
+
+export type LogEntry = {
+  id: number
+  imageUrl: string
+  direction: string
+  classes: string[]
+  createdAt: string
+  confidence: number
+}
+
+export type GetLogsResponse = {
+  totalPage: number
+  logs: LogEntry[]
+}
+
+export async function fetchLogs(
+  page: number,
+  size: number,
+  classType?: string,
+  directionType?: string
+): Promise<GetLogsResponse> {
+  const response = await axios.get<GetLogsResponse>(
+    'http://15.164.163.252:8080/api/logs',
+    {
+      params: {
+        page,
+        size,
+        classType,
+        directionType,
+      },
+    }
+  )
+  return response.data
+}


### PR DESCRIPTION
### PR Type

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약
로그 테이블 페이지를 구현하였습니다.

### 상세 내용
- record 페이지
    - useState를 이용해 페이지 번호와 크기를 관리했습니다.
    - 리엑트 쿼리를 통해 로그 데이터를 비동기적으로 패칭하여 표시했습니다.
 
- useLog
    - API 연동
    - @tanstack/react-query기반으로 useLogQuery 훅을 생성했습니다.

- 로그 테이블 컴포넌트 구현 - RecordRable
    - antd의 Table, Tag 컴포넌트를 기반으로 테이블을 구성하였습니다.

### 이슈 번호


### 스크린샷(선택)
<img width="1510" alt="image" src="https://github.com/user-attachments/assets/c50355b2-478d-446c-81a5-f16683ac5da3" />

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/12309540-9487-4889-9483-390df92ba097" />
