### PR TITLE
[#issue23]카메라 확대 기능 추가 및 레이아웃 개선

### DIFF
--- a/src/components/WebcamAiortc.tsx
+++ b/src/components/WebcamAiortc.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import CameraBox from '@/components/CameraBox'
 import DirectionTag, { Direction } from '@/components/DirectionTag'
@@ -19,6 +19,7 @@ export default function WebcamAiortc() {
   const videoRef3 = useRef<HTMLVideoElement | null>(null)
 
   const videoRefs = [videoRef0, videoRef1, videoRef2, videoRef3]
+  const [expandedCam, setExpandedCam] = useState<number | null>(null)
 
   useEffect(() => {
     videoRefs.forEach((ref, index) => {
@@ -28,28 +29,22 @@ export default function WebcamAiortc() {
     })
   }, [])
 
+  const handleBackgroundClick = () => {
+    if (expandedCam !== null) setExpandedCam(null)
+  }
+
   const detectColorChange = (video: HTMLVideoElement, direction: Direction) => {
     const canvas = document.createElement('canvas')
     const ctx = canvas.getContext('2d')
     let lastColor = ''
 
     const analyze = () => {
-      if (!ctx) {
-        console.warn(`[${direction}] ctx 생성 실패`)
-        requestAnimationFrame(analyze)
-        return
-      }
-
-      if (video.readyState < 2) {
-        console.log(
-          `[${direction}] video.readyState=${video.readyState} (재생 준비 안됨)`
-        )
-        requestAnimationFrame(analyze)
-        return
-      }
-
-      if (video.videoWidth === 0 || video.videoHeight === 0) {
-        console.log(`[${direction}] video width/height가 0`)
+      if (
+        !ctx ||
+        video.readyState < 2 ||
+        video.videoWidth === 0 ||
+        video.videoHeight === 0
+      ) {
         requestAnimationFrame(analyze)
         return
       }
@@ -84,48 +79,100 @@ export default function WebcamAiortc() {
       requestAnimationFrame(analyze)
     }
 
-    console.log(`[${direction}] detectColorChange 시작`)
     analyze()
   }
 
   return (
     <div
-      style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+      }}
     >
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: '1fr 1fr',
-          gridTemplateRows: '1fr 1fr',
-          gap: '10px',
-          width: '90vw',
-          maxWidth: '1460px',
-          maxHeight: 'calc(100vh - 120px)',
-        }}
-      >
-        {[0, 1, 2, 3].map((cam) => (
-          <div
-            key={cam}
-            style={{
-              position: 'relative',
-              width: '100%',
-              height: '100%',
-              backgroundColor: '#000',
-              borderRadius: '8px',
-              overflow: 'hidden',
-              aspectRatio: '16 / 9',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <CameraBox camNum={cam} videoRef={videoRefs[cam]} />
-            <div style={{ position: 'absolute', bottom: '8px', right: '8px' }}>
-              <DirectionTag direction={DIRECTION_LABELS[cam]} />
-            </div>
+      {expandedCam !== null && (
+        <div
+          onClick={handleBackgroundClick}
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            zIndex: 10,
+            width: '100vw',
+            height: '100vh',
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
+          }}
+        />
+      )}
+
+      {expandedCam !== null && (
+        <div
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            position: 'fixed',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            width: '90vw',
+            maxWidth: '1280px',
+            aspectRatio: '16 / 9',
+            backgroundColor: '#000',
+            borderRadius: '12px',
+            overflow: 'hidden',
+            zIndex: 20,
+            boxShadow: '0 0 20px rgba(0,0,0,0.7)',
+          }}
+        >
+          <CameraBox camNum={expandedCam} videoRef={videoRefs[expandedCam]} />
+          <div style={{ position: 'absolute', bottom: '8px', right: '8px' }}>
+            <DirectionTag direction={DIRECTION_LABELS[expandedCam]} />
           </div>
-        ))}
-      </div>
+        </div>
+      )}
+
+      {expandedCam === null && (
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            gridTemplateRows: '1fr 1fr',
+            gap: '10px',
+            width: '90vw',
+            maxWidth: '1460px',
+            maxHeight: 'calc(100vh - 120px)',
+          }}
+        >
+          {[0, 1, 2, 3].map((cam) => (
+            <div
+              key={cam}
+              onClick={(e) => {
+                e.stopPropagation()
+                setExpandedCam(cam)
+              }}
+              style={{
+                position: 'relative',
+                width: '100%',
+                height: '100%',
+                backgroundColor: '#000',
+                borderRadius: '8px',
+                overflow: 'hidden',
+                aspectRatio: '16 / 9',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                cursor: 'pointer',
+              }}
+            >
+              <CameraBox camNum={cam} videoRef={videoRefs[cam]} />
+              <div
+                style={{ position: 'absolute', bottom: '8px', right: '8px' }}
+              >
+                <DirectionTag direction={DIRECTION_LABELS[cam]} />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
### PR Type

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약
카메라 확대 기능 추가 및 레이아웃 개선

### 상세 내용
- 카메라 확대 기능 추가
    - 각 4분할 카메라 박스를 클릭 시 해당 화면을 전체 확대하여 표시
    - 확대된 화면 여백을 클릭하면 다시 4분할 화면으로 돌아감

- UI 레이아웃 수정
    - 전체 화면(fixed) 확대 시 배경 어두운 블러 처리 추가 (rgba(0, 0, 0, 0.5))
    - 16 / 9 고정으로 반응형 유지
    - 확대된 화면도 DirectionTag 표시 유지

### 이슈 번호
#23 

### 스크린샷(선택)
4분할 그리드 화면
<img width="1510" alt="스크린샷 2025-06-02 오후 8 31 35" src="https://github.com/user-attachments/assets/8eec18ba-3b37-4148-b668-c6b0e823fc68" />

카메라 확대 화면
<img width="1510" alt="스크린샷 2025-06-02 오후 8 31 54" src="https://github.com/user-attachments/assets/7ee883ab-22f4-49f2-b2d9-7373eea36881" />
