### PR TITLE
[#issue26] 로그 이미지 확대 기능 구현

### DIFF
--- a/app/dev/page.tsx
+++ b/app/dev/page.tsx
@@ -1,8 +1,0 @@
-export default function DevPage() {
-  return (
-    <main>
-      <h1>Dev Page</h1>
-      <p>이곳은 dev 페이지입니다.</p>
-    </main>
-  )
-}

--- a/src/components/RecordTable.tsx
+++ b/src/components/RecordTable.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 
-import { Table, Tag } from 'antd'
+import { Modal, Table, Tag } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 
 import { LogEntry } from '@/hooks/useLog'
@@ -34,6 +34,7 @@ const RecordTable = ({
 }: Props) => {
   const tableWrapperRef = useRef<HTMLDivElement>(null)
   const [scale, setScale] = useState(1)
+  const [selectedImageUrl, setSelectedImageUrl] = useState<string | null>(null)
 
   useEffect(() => {
     const handleResize = () => {
@@ -67,7 +68,9 @@ const RecordTable = ({
             alignItems: 'center',
             justifyContent: 'center',
             height: '40px',
+            cursor: 'pointer',
           }}
+          onClick={() => setSelectedImageUrl(url)}
         >
           <img
             src={url}
@@ -181,6 +184,45 @@ const RecordTable = ({
           }}
         />
       </div>
+
+      <Modal
+        open={!!selectedImageUrl}
+        footer={null}
+        onCancel={() => setSelectedImageUrl(null)}
+        centered
+        width="80%"
+        bodyStyle={{
+          textAlign: 'center',
+          padding: 0,
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        {selectedImageUrl && (
+          <div
+            style={{
+              width: '100%',
+              aspectRatio: '16 / 9',
+              position: 'relative',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <img
+              src={selectedImageUrl}
+              alt="확대 이미지"
+              style={{
+                width: '100%',
+                height: '100%',
+                objectFit: 'contain',
+                borderRadius: '8px',
+              }}
+            />
+          </div>
+        )}
+      </Modal>
     </div>
   )
 }

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { BiCamera, BiCodeAlt, BiDetail } from 'react-icons/bi'
+import { BiCamera, BiDetail } from 'react-icons/bi'
 
 import { Button, HStack, Icon } from '@chakra-ui/react'
 import { usePathname, useRouter } from 'next/navigation'
@@ -8,7 +8,6 @@ import { usePathname, useRouter } from 'next/navigation'
 const tabs = [
   { label: 'Camera', icon: BiCamera, route: '/' },
   { label: 'Record', icon: BiDetail, route: '/record' },
-  { label: 'Dev', icon: BiCodeAlt, route: '/dev' },
 ]
 
 const TabBar = () => {

--- a/src/components/WebcamAiortc.tsx
+++ b/src/components/WebcamAiortc.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useRef, useState } from 'react'
 
 import CameraBox from '@/components/CameraBox'
-import DirectionTag, { Direction } from '@/components/DirectionTag'
 import DelayLabel from '@/components/DelayLabel'
+import DirectionTag, { Direction } from '@/components/DirectionTag'
 
 const DIRECTION_LABELS: Record<number, Direction> = {
   0: 'front',
@@ -21,7 +21,12 @@ export default function WebcamAiortc() {
 
   const videoRefs = [videoRef0, videoRef1, videoRef2, videoRef3]
   const [expandedCam, setExpandedCam] = useState<number | null>(null)
-  const [delays, setDelays] = useState<(number | null)[]>([null, null, null, null])
+  const [delays, setDelays] = useState<(number | null)[]>([
+    null,
+    null,
+    null,
+    null,
+  ])
 
   const handleBackgroundClick = () => {
     if (expandedCam !== null) setExpandedCam(null)
@@ -35,7 +40,11 @@ export default function WebcamAiortc() {
     })
   }
 
-  const detectColorChange = (video: HTMLVideoElement, direction: Direction, camIndex: number) => {
+  const detectColorChange = (
+    video: HTMLVideoElement,
+    direction: Direction,
+    camIndex: number
+  ) => {
     const canvas = document.createElement('canvas')
     const ctx = canvas.getContext('2d')
     let lastColor = ''
@@ -179,7 +188,9 @@ export default function WebcamAiortc() {
               }}
             >
               <CameraBox camNum={cam} videoRef={videoRefs[cam]} />
-              <div style={{ position: 'absolute', bottom: '8px', right: '8px' }}>
+              <div
+                style={{ position: 'absolute', bottom: '8px', right: '8px' }}
+              >
                 <DirectionTag direction={DIRECTION_LABELS[cam]} />
               </div>
               <div style={{ position: 'absolute', top: '8px', left: '8px' }}>


### PR DESCRIPTION
### PR Type

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약
로그 이미지 확대 기능 구현

### 상세 내용
record table의 이미지를 누르면 해당 이미지가 확대됩니다.
이미지 우측 상단에 X나 이미지 외부의 여백을 클릭하면 record table로 다시 이동.
추가적으로 사용하지 않는 dev 페이지도 삭제했습니다. 

### 이슈 번호
#26 

### 스크린샷(선택)
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/cb78b1b2-817c-4493-9644-4e170660cc7b" />
